### PR TITLE
不要なアサートを削除

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -1522,7 +1522,6 @@ SDL_EventQueueElement SDL_EventQueueBegin() {
 }
 
 SDL_EventQueueElement SDL_EventQueueEnd() {
-    SDL_assert(SDL_EventQ.tail->next == NULL);
     return NULL;
 }
 


### PR DESCRIPTION
不要なアサートを削除

## Description
SDL_EventQueueEnd関数内のアサートを削除した．

## Existing Issue(s)
SDL_EventQueueEndの返り値がNULLで良いのかを迷っている．
  * 既存実装のforループをみたところ、SDL_EventQ.head->nextが適切そうに見える．
